### PR TITLE
Multiple links in Resource Data Access field

### DIFF
--- a/src/pages/participatingResourceDetailPage/ParticipatingResourceDetail.js
+++ b/src/pages/participatingResourceDetailPage/ParticipatingResourceDetail.js
@@ -430,7 +430,13 @@ const ParticipatingResourceDetail = ({
                         <br />
                           {
                             detail.api
-                            ? <a href={detail.api} target="_blank" rel="noreferrer noopener">{detail.api}</a>
+                            ? detail.api.split(',').map((item, idx) => {
+                              const key = `sort_${idx}`;
+                              const newItem = item.trim();
+                              return (
+                                <div key={key}><a href={newItem} target="_blank" rel="noreferrer noopener">{newItem}</a></div>
+                              );
+                            })
                             : null
                           }
                       </div>


### PR DESCRIPTION
Task PODCAT-780
Update the Data Access field on the Resource details page to handle multiple links. Links are separated by comma and I also delete the extra spaces.