### PR TITLE
PODCAT-786 External link and icon are on separate line

### DIFF
--- a/src/pages/participatingResourcesPage/SearchResult/SearchResult.js
+++ b/src/pages/participatingResourcesPage/SearchResult/SearchResult.js
@@ -271,7 +271,7 @@ const SearchResult = ({
                     </POCInfo>
                     <SiteInfo>
                       <a href={rst.resource_uri} target="_blank" rel="noreferrer noopener">
-                        {rst.resource_uri && rst.resource_uri.length > 70 ? `${rst.resource_uri.substring(0, 80)}...` : rst.resource_uri}
+                        {rst.resource_uri && rst.resource_uri.length > 70 ? `${rst.resource_uri.substring(0, 70)}...` : rst.resource_uri}
                         <SiteIcon />
                       </a>
                     </SiteInfo>


### PR DESCRIPTION
Fixed the bug for the URL line and the link-out icon should appear on the same line