### PR TITLE
PODCAT-890: Incorrect text wrapping in tooltip description

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,4 +39,9 @@ nav {
   max-width: 220px;
   border-radius: 6px;
   font-size: 12px;
+  word-wrap: normal;
+}
+
+.popover-body {
+  padding: 10px;
 }


### PR DESCRIPTION
Added word-wrap: normal;